### PR TITLE
Resolves #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Creating a custom Stream handler is easy.  Just create a Class that has a
 
 **Custom Handler**
 ```python
-class custom_stream():
+class CustomStream():
     def __init__(self, *args, **kwargs):
         # Store Parameters and Connect to destination
 

--- a/faker_events/__main__.py
+++ b/faker_events/__main__.py
@@ -44,7 +44,7 @@ event_generator = EventGenerator(profiles_generator)
 if args.script:
     try:
         sys.path.append(os.getcwd())
-        module_path = args.script.rstrip(".py").replace("/", ".")
+        module_path = os.path.splitext(args.script)[0].replace("/", ".")
         event_script = importlib.import_module(module_path)
     except ModuleNotFoundError:
         eprint(f"ERROR: No event module named '{args.script}'", Palatte.RED)


### PR DESCRIPTION
### Purpose
Faker-Event python script not always loading from the command line interface.

### Approach
The character strip was not the proper way to remove the extension from the file name.
